### PR TITLE
One more little update I made...regarding where the first intervalEvent fires.

### DIFF
--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -36,8 +36,7 @@ angular.module('timer', [])
         //$scope.$on('event:save', function () {
         //$scope.$on('event:refreshData', function () {
         $scope.$on($scope.intervalEvent, function () {
-        		$scope.intervalEventCount++;
-        		$scope.intervalEventName = $scope.intervalEvent        		
+      		$scope.intervalEventName = $scope.intervalEvent        		
         });
         
         function resetTimeout() {
@@ -81,7 +80,10 @@ angular.module('timer', [])
             $scope.hours = Math.floor((($scope.millis / (1000*60*60)) % 24));
             
             if($scope.intervalEvent != undefined) {
-            	$rootScope.$broadcast($scope.intervalEvent);
+            	if($scope.intervalEventCount > 0) {
+            		$rootScope.$broadcast($scope.intervalEvent);
+            	}
+            	$scope.intervalEventCount++;
           	}
             
             $scope.timeoutId = $timeout(function () {


### PR DESCRIPTION
For my app, I decided that the intervalEvent should only fire at the end of the first interval, not on timer init.  I think this little change brings the intervalEvent more in line with expected behavior (at least for me).

I didn't notice it until I setup an event that I wanted to show 30 minutes into the application after first load but the intervalEvents started firing on the first tick, not after the first interval had elapsed.

In addition to autosave, I'm using this to run a ping event, keeping my server session alive and it didn't make sense to pop a dialog immediately after someone had logged in.

Thanks,
Timothy
