### PR TITLE
Make timer-start event restart countdown timer

### DIFF
--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -39,6 +39,7 @@ angular.module('timer', [])
 
                 $scope.start = $element[0].start = function () {
                     $scope.startTime = $scope.startTimeAttr ? new Date($scope.startTimeAttr) : new Date();
+                    $scope.countdown = $scope.countdownattr && parseInt($scope.countdownattr, 10) > 0 ? parseInt($scope.countdownattr, 10) : undefined;
                     resetTimeout();
                     tick();
                 };


### PR DESCRIPTION
The countdown timer was not starting from the countdownattr value after doing start->(wait >1s)->stop->start, so I added the initialisation of the countdown in the .start function. 

It's a good question whether the line should be abstracted into a function.

Another thing to consider is whether to use a simpler way to determine if the argument is a number. Assuming angular isNumber doesn't do the trick, see a plain-js option here:
http://stackoverflow.com/questions/18082/validate-numbers-in-javascript-isnumeric

I'm using angular-timer for http://worldmap.io (work-in-progress) if you want to see the use case

Thanks for an awesome little directive!
