### PR TITLE
Fixed timing issue where pausing and restarting a countdown timer would ...

### DIFF
--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -46,6 +46,9 @@ angular.module('timer', [])
 
                 $scope.resume = $element[0].resume = function () {
                     resetTimeout();
+                    if($scope.countdownattr){
+                        $scope.countdown += 1;
+                    }
                     $scope.startTime = new Date() - ($scope.stoppedTime - $scope.startTime);
                     tick();
                 };
@@ -79,8 +82,9 @@ angular.module('timer', [])
                 var tick = function () {
 
                     $scope.millis = new Date() - $scope.startTime;
-
-                    if ($scope.countdown > 0) {
+                    adjustment = $scope.millis % 1000;
+                    
+                    if ($scope.countdownattr) {
                         $scope.millis = $scope.countdown * 1000;
                     }
 
@@ -97,7 +101,7 @@ angular.module('timer', [])
                     $scope.timeoutId = setTimeout(function () {
                         tick();
                         $scope.$apply();
-                    }, $scope.interval);
+                    }, $scope.interval - adjustment);
 
                     $scope.$emit('timer-tick', {timeoutId: $scope.timeoutId, millis: $scope.millis});
                 };


### PR DESCRIPTION
...lead to loss of a chunk of a second (timer stops immediately but begins at the next whole second down). As a side-effect, also fixed minor drift, so instead of timing e.g. 9004 millis for 9 seconds, now it comes closer to 9000 precusely
