### PR TITLE
*adds 'timer-end' event and $scope.end function

### DIFF
--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -69,7 +69,7 @@ angular.module('timer', [])
                     $scope.$emit('timer-stopped', {millis: $scope.millis, seconds: $scope.seconds, minutes: $scope.minutes, hours: $scope.hours, days: $scope.days});
                     $scope.timeoutId = null;
                 };
-				
+
                 $scope.end = $element[0].end = function () {
                     resetTimeout();
                     $scope.startTime = null;
@@ -90,9 +90,14 @@ angular.module('timer', [])
 
                 function calculateTimeUnits() {
                     $scope.seconds = Math.floor(($scope.millis / 1000) % 60);
-                    $scope.minutes = Math.floor((($scope.millis / (60000)) % 60));
-                    $scope.hours = Math.floor((($scope.millis / (3600000)) % 24));
-                    $scope.days = Math.floor((($scope.millis / (3600000)) / 24));
+                    $scope.minutes = Math.floor(($scope.millis / 60000) % 60);
+                    $scope.hours = Math.floor(($scope.millis / 3600000) % 24);
+
+                    $scope.fullSeconds = Math.floor($scope.millis / 1000);
+                    $scope.fullMinutes = Math.floor($scope.millis / 60000);
+                    $scope.fullHours = Math.floor($scope.millis / 3600000);
+
+                    $scope.days = Math.floor(($scope.millis / 3600000) / 24);
                 }
 
                 //determine initial values of time units


### PR DESCRIPTION
*adds 'timer-end' event and $scope.end() function
*adds 'timer-resumed' and 'timer-started' events
*BREAKING CHANGE: changes the function called after end of countdown from $scope.stop() to $scope.end()

There is a general semantic issue with the 'end' and 'ended' events. They are there to signify both 'pause' and 'end'. This means that the timer is also not properly restarted (or restartable). I assume this comes from the fact that countdown functionality was added later, and that's when the pause/end distinciton is important.

The problem is that simply removing stop() is a hugely breaking change. So I chose to leave it as-is as a 'synonym' for 'pause', and introduced 'end' as a new event. However this means I must make the lesser breaking change of reconfiguring which event gets triggerred on the end of the countdown. This isn't as much of a problem as the use of $scope.stop() was kind of problematic anyway. There was no way to restart the countdown, so you could only really do a countdown once.

Hopefully this change makes sense, let me know if not.
