### PR TITLE
Fix dynamic templating for Angular 1.2

### DIFF
--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -10,14 +10,18 @@ angular.module('timer', [])
         autoStart: '&autoStart'
       },
       controller: ['$scope', '$element', '$attrs', function ($scope, $element, $attrs) {
+        var elHtml;
+
         //angular 1.2 doesn't support attributes ending in "-start", so we're
         //supporting both "autostart" and "auto-start" as a solution for
         //backward and forward compatibility.
         $scope.autoStart = $attrs.autoStart || $attrs.autostart;
 
-        if ($element.html().trim().length === 0) {
-          $element.append($compile('<span>{{millis}}</span>')($scope));
+        elHtml = $element.html();
+        if (elHtml.trim().length === 0) {
+          elHtml = '{{millis}}';
         }
+        $element.replaceWith($compile('<span>' + elHtml + '</span>')($scope));
 
         $scope.startTime = null;
         $scope.timeoutId = null;


### PR DESCRIPTION
Small fix which should take care of https://github.com/siddii/angular-timer/issues/29

If the timer tag has dynamic content (e.g., `<timer>my content with {{seconds}} etc</timer>`), the controller now treats it the same way as it does in the default case (`<timer/>`, which inserts `<span>{{millis}}</span>`): it grabs the desired markup from the element and `$compile`s it with the timer's isolated scope; otherwise in Angular 1.2 it would get rendered with the parent scope and have no access to the timer's scope vars.

This does wrap the dynamic content in `span` tags so that Angular can compile it properly. Maybe it would make more sense for them to be `div`s so that you could use almost any arbitrary markup within the `timer` tag.
