### PR TITLE
Manage the isRunning flag and allow clearing a countdown

### DIFF
--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -41,6 +41,10 @@ angular.module('timer', [])
           $scope.stop();
         });
 
+        $scope.$on('timer-clear', function () {
+          $scope.clear();
+        });
+
         function resetTimeout() {
           if ($scope.timeoutId) {
             clearTimeout($scope.timeoutId);
@@ -53,6 +57,7 @@ angular.module('timer', [])
           $scope.countdown = $scope.countdownattr && parseInt($scope.countdownattr, 10) > 0 ? parseInt($scope.countdownattr, 10) : undefined;
           resetTimeout();
           tick();
+          $scope.isRunning = true;
         };
 
         $scope.resume = $element[0].resume = function () {
@@ -62,6 +67,7 @@ angular.module('timer', [])
           }
           $scope.startTime = new Date() - ($scope.stoppedTime - $scope.startTime);
           tick();
+          $scope.isRunning = true;
         };
 
         $scope.stop = $scope.pause = $element[0].stop = $element[0].pause = function () {
@@ -69,10 +75,20 @@ angular.module('timer', [])
           resetTimeout();
           $scope.$emit('timer-stopped', {millis: $scope.millis, seconds: $scope.seconds, minutes: $scope.minutes, hours: $scope.hours, days: $scope.days});
           $scope.timeoutId = null;
+          $scope.isRunning = false;
+        };
+
+        $scope.clear = $element[0].clear = function () {
+          // same as stop but without the event being triggered
+          $scope.stoppedTime = new Date();
+          resetTimeout();
+          $scope.timeoutId = null;
+          $scope.isRunning = false;
         };
 
         $element.bind('$destroy', function () {
           resetTimeout();
+          $scope.isRunning = false;
         });
 
         function calculateTimeUnits() {


### PR DESCRIPTION
This merge request implements management of the isRunning flag which may be used for (amongst other things, perhaps) hiding or displaying the timer display depending on whether the timer is running using a simple ng-show="isRunning", for example:

```
  <timer autostart="false" interval="1000" countdown="timerLimit">
    <div ng-show="isRunning">
      Time left to complete this section: {{ millis | date:'m:ss' }}
    </div>
  </timer>
```

It also adds an event that an application may use to clear a running timer. This allows the application to cancel / stop the timer (and hide it if the above flag is used) but not generate the "stopped" event back out of the timer.

When combined, these two elements allow the display of a countdown timer on a page when appropriate, and hide it when not, and cancel it without generating a "timed out" error when appropriate.
