### PR TITLE
Added listener to be able to set countdown value

### DIFF
--- a/dist/angular-timer.js
+++ b/dist/angular-timer.js
@@ -52,10 +52,6 @@ angular.module('timer', [])
           $scope.clear();
         });
 
-        $scope.$on('countdown-set', function (e, countdown) {
-          $scope.countdown = countdown;
-        });
-        
         function resetTimeout() {
           if ($scope.timeoutId) {
             clearTimeout($scope.timeoutId);


### PR DESCRIPTION
With the listener one can set the countdown value using
`$broadcast('countdown-set', value)`. This might be an edge case, but I
need to set a new countdown. Issue #23 describes how to set the value on initialization but using
this one can change the value whenever necessary.

Also changed the order of execution of some code to make 0 the last emitted millis value
for a countdown. In the original code the last emit message was the value just
before 0. For example with a countdown with an interval of 1000 the last
emitted millis value was 1000.
