### PR TITLE
Added prevent event 'timer-stopped' on elements selected 

### DIFF
--- a/dist/angular-timer.js
+++ b/dist/angular-timer.js
@@ -23,6 +23,8 @@ angular.module('timer', [])
         //supporting both "autostart" and "auto-start" as a solution for
         //backward and forward compatibility.
         $scope.autoStart = $attrs.autoStart || $attrs.autostart;
+        //trigger event
+        $scope.eventstop = $attrs.eventstop;
 
         if ($element.html().trim().length === 0) {
           $element.append($compile('<span>{{millis}}</span>')($scope));
@@ -73,6 +75,17 @@ angular.module('timer', [])
           $scope.isRunning = true;
         };
 
+        $scope.getCurrentTime = $element[0].getCurrentTime = function () {
+          return { 
+            millis: $scope.millis, 
+            seconds: $scope.seconds, 
+            minutes: $scope.minutes, 
+            hours: $scope.hours, 
+            days: $scope.days
+
+          }
+        };
+
         $scope.resume = $element[0].resume = function () {
           resetTimeout();
           if ($scope.countdownattr) {
@@ -85,7 +98,12 @@ angular.module('timer', [])
 
         $scope.stop = $scope.pause = $element[0].stop = $element[0].pause = function () {
           $scope.clear();
-          $scope.$emit('timer-stopped', {millis: $scope.millis, seconds: $scope.seconds, minutes: $scope.minutes, hours: $scope.hours, days: $scope.days});
+          
+          if ($scope.eventstop != 'false') {
+            $scope.$emit('timer-stopped', {millis: $scope.millis, seconds: $scope.seconds, minutes: $scope.minutes, hours: $scope.hours, days: $scope.days});
+
+          } 
+
         };
 
         $scope.clear = $element[0].clear = function () {


### PR DESCRIPTION
Hi 

I have several timers running in the same time with different values and when every timer has ended,  the event 'timer-stopped' is triggered for every one. I needed that only one specific timer was the responsable to trigger this event.

Also I needed to know the current values on seconds to make some calculations, so I added the method "getCurrentTime ()" to get that values.

Just wondering if you want to consider add this to your project. sorry is my first fork :(
