### PR TITLE
Added support for specifying a timer name.  Timers with a timerName prop...

### DIFF
--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -40,9 +40,9 @@ angular.module('timer', [])
         $scope.isRunning = false;
 
         function executeOnTimerName (args, fn) {
-            if ($scope.timerName && args.timerName == $scope.timerName) {
-                fn();
-            }
+          if (!args || !args.timerName || ($scope.timerName && args.timerName == $scope.timerName)) {
+            fn();
+          }
         }
 
         $scope.$on('timer-start', function (evt, args) {
@@ -103,7 +103,7 @@ angular.module('timer', [])
         $scope.stop = $scope.pause = $element[0].stop = $element[0].pause = function () {
           var timeoutId = $scope.timeoutId;
           $scope.clear();
-          $scope.$emit('timer-stopped', {timeoutId: timeoutId, millis: $scope.millis, seconds: $scope.seconds, minutes: $scope.minutes, hours: $scope.hours, days: $scope.days});
+          $scope.$emit('timer-stopped', {timeoutId: timeoutId, millis: $scope.millis, seconds: $scope.seconds, minutes: $scope.minutes, hours: $scope.hours, days: $scope.days, timerName: $scope.timerName});
         };
 
         $scope.clear = $element[0].clear = function () {
@@ -243,7 +243,7 @@ angular.module('timer', [])
             $scope.$digest();
           }, $scope.interval - adjustment);
 
-          $scope.$emit('timer-tick', {timeoutId: $scope.timeoutId, millis: $scope.millis});
+          $scope.$emit('timer-tick', {timeoutId: $scope.timeoutId, millis: $scope.millis, timerName: $scope.timerName});
 
           if ($scope.countdown > 0) {
             $scope.countdown--;

--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -9,7 +9,8 @@ angular.module('timer', [])
         endTimeAttr: '=endTime',
         countdownattr: '=countdown',
         autoStart: '&autoStart',
-        maxTimeUnit: '='
+        maxTimeUnit: '=',
+        timerName: '='
       },
       controller: ['$scope', '$element', '$attrs', '$timeout', function ($scope, $element, $attrs, $timeout) {
 
@@ -38,20 +39,34 @@ angular.module('timer', [])
         $scope.countdown = $scope.countdownattr && parseInt($scope.countdownattr, 10) >= 0 ? parseInt($scope.countdownattr, 10) : undefined;
         $scope.isRunning = false;
 
-        $scope.$on('timer-start', function () {
-          $scope.start();
+        function executeOnTimerName (args, fn) {
+            if ($scope.timerName && args.timerName == $scope.timerName) {
+                fn();
+            }
+        }
+
+        $scope.$on('timer-start', function (evt, args) {
+          executeOnTimerName(args, function() {
+              $scope.start();
+          });
         });
 
-        $scope.$on('timer-resume', function () {
-          $scope.resume();
+        $scope.$on('timer-resume', function (evt, args) {
+            executeOnTimerName(args, function() {
+                $scope.resume();
+            });
         });
 
-        $scope.$on('timer-stop', function () {
-          $scope.stop();
+        $scope.$on('timer-stop', function (evt, args) {
+            executeOnTimerName(args, function() {
+                $scope.stop();
+            });
         });
 
-        $scope.$on('timer-clear', function () {
-          $scope.clear();
+        $scope.$on('timer-clear', function (evt, args) {
+            executeOnTimerName(args, function() {
+                $scope.clear();
+            });
         });
 
         $scope.$on('timer-set-countdown', function (e, countdown) {


### PR DESCRIPTION
...erty set will only respond to start, stop, resume, and clear events if the timer's name is specified on the event args.

This should allow for multiple timers of different purposes nested underneath a single controller.  This change only adds support for the start, stop, resume and clear events.  Adding support for the timer-set-countdown event looked like it would induce a breaking change, so I skipped it for now.

What are your thoughts on this?
