### PR TITLE
add missing {{countdown}} to countdown timer example docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
 
     <div class="bs-docs-example">
         <p>
-            The countdown timer <code ng-non-bindable="">&lt;timer interval=&quot;1000&quot; countdown=&quot;100&quot;/&gt;</code>
+            The countdown timer <code ng-non-bindable="">&lt;timer interval=&quot;1000&quot; countdown=&quot;100&quot;&gt;{{countdown}}&lt;/timer&gt;</code>
             will start its countdown from 100 until it reaches 0 by ticking every second</p>
 
         <h3>


### PR DESCRIPTION
 Hello,

Looks like the "countdown" example is not 100% accurate, so I fixed it. Let me know if there are any Qs.

Thanks!
