### PR TITLE
Update angular-timer.js

### DIFF
--- a/dist/angular-timer.js
+++ b/dist/angular-timer.js
@@ -253,6 +253,7 @@ var timerModule = angular.module('timer', [])
           }
         };
 
+        $scope.autoStart = $scope.$eval($scope.autoStart);
         if ($scope.autoStart === undefined || $scope.autoStart === true) {
           $scope.start();
         }


### PR DESCRIPTION
Issue found:
autoStart attribute does not properly work on the directive.
1) autoStart does not exists: Timer starts automatically (expected behaviour).
2) autoStart exists, set to fasle: Timer starts automatically (expected behaviour).
2) autoStart exists, set to true: Timer does not start automatically (NOT expected behaviour).

This happens because variable $scope.autoStart (on line 256 in the "if" statement) is a 'string' type.
So "$scope.autoStart === true" never passes.

Proposal solution will fix the problem with variable type.
