### PR TITLE
Fixes bower ignore list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,5 +17,8 @@
       "angular-mocks": ">= 1.0.7"
   },
   "main": "./dist/angular-timer.js",
-  "ignore": ["./node_modules/", "./bower_components/"]
+  "ignore": [
+    "node_modules",
+    "bower_components"
+  ]
 }


### PR DESCRIPTION
`bower_components` was not being correctly ignored when doing `bower install angular-timer`.
