### PR TITLE
Add adaptive interpolation symbol

### DIFF
--- a/app/js/timer.js
+++ b/app/js/timer.js
@@ -12,7 +12,7 @@ var timerModule = angular.module('timer', [])
         autoStart: '&autoStart',
         maxTimeUnit: '='
       },
-      controller: ['$scope', '$element', '$attrs', '$timeout', function ($scope, $element, $attrs, $timeout) {
+      controller: ['$scope', '$element', '$attrs', '$timeout', '$interpolate', function ($scope, $element, $attrs, $timeout, $interpolate) {
 
         // Checking for trim function since IE8 doesn't have it
         // If not a function, create tirm with RegEx to mimic native trim
@@ -28,7 +28,7 @@ var timerModule = angular.module('timer', [])
         $scope.autoStart = $attrs.autoStart || $attrs.autostart;
 
         if ($element.html().trim().length === 0) {
-          $element.append($compile('<span>{{millis}}</span>')($scope));
+          $element.append($compile('<span>' + $interpolate.startSymbol() + 'millis' + $interpolate.endSymbol() + '</span>')($scope));
         } else {
           $element.append($compile($element.contents())($scope));
         }

--- a/index.html
+++ b/index.html
@@ -111,11 +111,11 @@
 
     <div class="bs-docs-example">
         <p>
-            Following is the countdown timer setting for the days, hours, minutes & seconds to <b>January 1, 2015 (GMT-6) </b>
-            <p class="muted">(01 Jan 2015 06:00:00 GMT = 1420070400000 milliseconds)</p>
-            <code ng-non-bindable="">&lt;timer end-time=&quot;1420070400000&quot;&gt;{{days}} days, {{hours}} hours, {{minutes}} minutes, {{seconds}} seconds.&lt;/timer&gt;</code>
+            Following is the countdown timer setting for the days, hours, minutes & seconds to <b>January 1, 2016 (GMT-6) </b>
+            <p class="muted">(01 Jan 2016 06:00:00 GMT = 1451628000000 milliseconds)</p>
+            <code ng-non-bindable="">&lt;timer end-time=&quot;1451628000000&quot;&gt;{{days}} days, {{hours}} hours, {{minutes}} minutes, {{seconds}} seconds.&lt;/timer&gt;</code>
         <h3>
-            <timer end-time="1420070400000">{{days}} days, {{hours}} hours, {{minutes}} minutes, {{seconds}} seconds.</timer>
+            <timer end-time="1451628000000">{{days}} days, {{hours}} hours, {{minutes}} minutes, {{seconds}} seconds.</timer>
         </h3>
     </div>
 </section>


### PR DESCRIPTION
To deal with #111, how about letting interpolation symbol change adaptively?

Actually, when i use Django as my backend web framework, i always change the `$interpolateProvide` symbol. I think it's suitable to be adaptive.