### PR TITLE
Changed MomentJS alias

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "angular": ">= 1.0.7",
-    "momentjs": "~2.9.0",
+    "moment": "~2.9.0",
     "humanize-duration": "~2.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The main dependency of moment is just moment, not momentjs which causes a separate folder in the components. This change is necessary if you have a highly modular approach where each module has moment as dependency with different overrides, e.g. for language.