### PR TITLE
fix comment style causing an error in IE10-

### DIFF
--- a/app/js/i18nService.js
+++ b/app/js/i18nService.js
@@ -22,7 +22,7 @@ app.factory('I18nService', function() {
         }
 
         //moment init
-        moment.locale(this.language); //@TODO maybe to remove, it should be handle by the user's application itself, and not inside the directive
+        moment.locale(this.language); // @TODO maybe to remove, it should be handle by the user's application itself, and not inside the directive
 
         //human duration init, using it because momentjs does not allow accurate time (
         // momentJS: a few moment ago, human duration : 4 seconds ago

--- a/dist/angular-timer.js
+++ b/dist/angular-timer.js
@@ -377,7 +377,7 @@ app.factory('I18nService', function() {
         }
 
         //moment init
-        moment.locale(this.language); //@TODO maybe to remove, it should be handle by the user's application itself, and not inside the directive
+        moment.locale(this.language); // @TODO maybe to remove, it should be handle by the user's application itself, and not inside the directive
 
         //human duration init, using it because momentjs does not allow accurate time (
         // momentJS: a few moment ago, human duration : 4 seconds ago


### PR DESCRIPTION
IE10 and earlier interpret //@ as a type of conditional, and triggers the following error if not formatted as such.

<img width="738" alt="screen shot 2016-08-10 at 10 38 36" src="https://cloud.githubusercontent.com/assets/11376/17549137/d062a5cc-5ee6-11e6-9714-8670735e2278.png">

This causes me problems during testing in development mode as the comments are not stripped out at this point.

http://msdn.microsoft.com/en-us/library/8ka90k2e(v=vs.94).aspx