### PR TITLE
Timer with predefined endTime doesn't resume from stoppedTime

### DIFF
--- a/dist/angular-timer.js
+++ b/dist/angular-timer.js
@@ -146,6 +146,7 @@ var timerModule = angular.module('timer', [])
             $scope.countdown += 1;
           }
           $scope.startTime = moment().diff((moment($scope.stoppedTime).diff(moment($scope.startTime))));
+          $scope.endTime += moment().diff(moment($scope.stoppedTime));
           tick();
           $scope.isRunning = true;
           $scope.$emit('timer-started', {


### PR DESCRIPTION
Timer with predefined endTime doesn't resume from the time when it was stopped.
Check the example - [example](https://codepen.io/anon/pen/QaJENJ)
Solution: update endTime according to the time when timer resumes.

Intuitive digramm showing current implementation :
<img width="1301" alt="screen shot 2018-01-18 at 11 29 14 pm" src="https://user-images.githubusercontent.com/16737943/35122438-72393ad2-fca7-11e7-9aee-ff8ee92f15df.png">

After fix :
<img width="1110" alt="screen shot 2018-01-18 at 10 55 09 pm" src="https://user-images.githubusercontent.com/16737943/35121099-f74c1e6a-fca2-11e7-8f08-cf10a1106e69.png">
